### PR TITLE
Set up Containerization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Flask
+instance/
+.flask_sessions/
+.flaskenv
+
+# Environments
+.env
+.venv
+env/
+venv/
+
+# Testing
+.pytest_cache/
+
+# mypy
+.mypy_cache/
+
+# MkDocs
+/site
+
+# VS Code
+.vscode/settings.json
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM --platform=linux/amd64 python:3.9-alpine
+
+WORKDIR /app
+
+COPY ./requirements.txt requirements.txt
+
+RUN pip install --no-cache-dir --upgrade -r requirements.txt
+
+COPY . .
+
+CMD ["/bin/sh", "docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Synchronize database schema
+flask db migrate -m "Test"  # NOTE: Unnecessary once stable schema is committed
+flask db upgrade
+
+# Launch application
+exec gunicorn --bind 0.0.0.0:80 "app:app"

--- a/poetry.lock
+++ b/poetry.lock
@@ -357,6 +357,26 @@ docs = ["Sphinx"]
 test = ["objgraph", "psutil"]
 
 [[package]]
+name = "gunicorn"
+version = "21.2.0"
+description = "WSGI HTTP Server for UNIX"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "gunicorn-21.2.0-py3-none-any.whl", hash = "sha256:3213aa5e8c24949e792bcacfc176fef362e7aac80b76c56f6b5122bf350722f0"},
+    {file = "gunicorn-21.2.0.tar.gz", hash = "sha256:88ec8bff1d634f98e61b9f65bc4bf3cd918a90806c6f5c48bc5603849ec81033"},
+]
+
+[package.dependencies]
+packaging = "*"
+
+[package.extras]
+eventlet = ["eventlet (>=0.24.1)"]
+gevent = ["gevent (>=1.4.0)"]
+setproctitle = ["setproctitle"]
+tornado = ["tornado (>=0.2)"]
+
+[[package]]
 name = "identify"
 version = "2.5.29"
 description = "File identification library for Python"
@@ -1062,4 +1082,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "976711165507e4a3aee40e5fdbd0c4779af8cf2eb4702cd35c673883245989fc"
+content-hash = "03f422aed987361f75f55d0dc93d404bb8f406b61c8945c23afc6564cabff03f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ flask-wtf = "^1.2.1"
 pytest-mock = "^3.12.0"
 flask-sqlalchemy = "^3.1.1"
 flask-migrate = "^4.0.5"
+gunicorn = "^21.2.0"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.4.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -95,6 +95,9 @@ greenlet==3.0.1 ; python_version >= "3.9" and python_version < "4.0" and (platfo
     --hash=sha256:f7bfb769f7efa0eefcd039dd19d843a4fbfbac52f1878b1da2ed5793ec9b1a65 \
     --hash=sha256:f89e21afe925fcfa655965ca8ea10f24773a1791400989ff32f467badfe4a064 \
     --hash=sha256:fa24255ae3c0ab67e613556375a4341af04a084bd58764731972bcbc8baeba36
+gunicorn==21.2.0 ; python_version >= "3.9" and python_version < "4.0" \
+    --hash=sha256:3213aa5e8c24949e792bcacfc176fef362e7aac80b76c56f6b5122bf350722f0 \
+    --hash=sha256:88ec8bff1d634f98e61b9f65bc4bf3cd918a90806c6f5c48bc5603849ec81033
 importlib-metadata==6.8.0 ; python_version >= "3.9" and python_version < "3.10" \
     --hash=sha256:3ebb78df84a805d7698245025b975d9d67053cd94c79245ba4b3eb694abe68bb \
     --hash=sha256:dbace7892d8c0c4ac1ad096662232f831d4e64f4c4545bd53016a3e9d4654743


### PR DESCRIPTION
# Description

This PR sets up containerization of the Flask app for more effective deployment. Currently, the Docker image is hosted in a private DDSS repo on DockerHub and is used to deploy a demo version of the app for PIs and internal testing. The plan is to eventually make the DockerHub repo public such that users may pull and deploy the Docker image easily.