### PR TITLE
Ensure data integrity

### DIFF
--- a/safely_report/models.py
+++ b/safely_report/models.py
@@ -214,18 +214,21 @@ class SurveyResponse(db.Model):  # type: ignore
 
 
 @event.listens_for(SurveyResponse, "after_insert")
-def update_respondent_status(
+def update_respondent_info(
     mapper: Mapper,
     connection: Connection,
     target: SurveyResponse,
 ):
     """
-    Mark respondent status as complete when their response is submitted.
+    Update respondent information when their response is submitted.
     """
     connection.execute(
         update(Respondent)
         .where(Respondent.uuid == target.respondent_uuid)
-        .values(survey_status=SurveyStatus.Complete)
+        .values(
+            survey_status=SurveyStatus.Complete,
+            enumerator_uuid=target.enumerator_uuid,
+        )
     )
 
 


### PR DESCRIPTION
# Description

This PR make a small update in a DB event listener such that response submission triggers an update of respondent's enumerator info along with the survey status.

This change is intended for ensuring integrity between response and respondent tables. For instance, it is possible that the admin reassigns a respondent to another enumerator while the respondent actually started (but have not yet finished) taking the survey with the originally assigned enumerator. This reassignment then creates a drift between response and respondent tables. Hence, we want to sync the assigned enumerator information between the two tables.

Note that covariates for block garbling are not much subject to this type of stale-data issue because they are fetched and used instantly during the response submission step.