### PR TITLE
Prevent enumerator deletion after response submission

### DIFF
--- a/safely_report/admin/views.py
+++ b/safely_report/admin/views.py
@@ -128,14 +128,22 @@ class RespondentModelView(SurveyModelView):
     # Prevent changes to respondent info once their response is submitted
     def update_model(self, form, model):
         if model.survey_status == SurveyStatus.Complete:
-            flash("Completed respondent cannot be edited.", "error")
+            message = (
+                f"{str(model)} cannot be updated because "
+                "they already completed survey."
+            )
+            flash(message, "error")
             return False
         return super().update_model(form, model)
 
-    # Prevent removal of respondent info once their response is submitted
+    # Prevent deletion of respondent record once their response is submitted
     def delete_model(self, model):
         if model.survey_status == SurveyStatus.Complete:
-            flash("Completed respondent cannot be deleted.", "error")
+            message = (
+                f"{str(model)} cannot be deleted because "
+                "they already completed survey."
+            )
+            flash(message, "error")
             return False
         return super().delete_model(model)
 
@@ -177,8 +185,12 @@ class RespondentModelView(SurveyModelView):
             count = 0
             for respondent in respondents:
                 if respondent.survey_status == SurveyStatus.Complete:
-                    flash("Completed respondent cannot be edited.", "error")
-                    continue
+                    message = (
+                        f"{str(respondent)} cannot be updated because "
+                        "they already completed survey."
+                    )
+                    flash(message, "error")
+                    continue  # Skip to next respondent
                 respondent.enumerator = enumerator
                 count += 1
 


### PR DESCRIPTION
# Description

This PR makes updates to prevent deletion of an enumerator record once the enumerator submits response on behalf of their assigned respondent. This protection is necessary for preserving data integrity (i.e., we should be able to track which enumerator assisted which respondent).

We do not prohibit enumerator updates for now, but this may change later if PIs demand more constraints.
