### PR TITLE
Integrate PI feedback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine
+FROM --platform=linux/amd64 python:3.9-alpine
 
 WORKDIR /app
 

--- a/safely_report/templates/survey/index.html
+++ b/safely_report/templates/survey/index.html
@@ -13,56 +13,40 @@
     {% set garbling_answer = choices[garbling_params.answer] %}
     {% set garbling_percent = (garbling_params.rate * 100) | int %}
     {% set garbling_covariate = garbling_params.covariate %}
-    <div class="alert alert-primary p-0 border-2">
-      <div class="accordion" id="singleAccordion">
-        <div class="accordion-item border-0">
-          <h2 class="accordion-header">
-            <button
-              class="accordion-button collapsed"
-              type="button"
-              data-bs-toggle="collapse"
-              data-bs-target="#singleAccordionCollapse"
-            >
-              <i class="bi bi-info-circle" style="font-size: x-large; color: cornflowerblue;"></i>
-              <span class="px-4">
-                This question uses "garbling"
-                to keep your response private.
-              </span>
-            </button>
-          </h2>
-          <div
-            id="singleAccordionCollapse"
-            class="accordion-collapse collapse"
-            data-bs-parent="#singleAccordion"
-          >
-            <div class="accordion-body">
-              {% if garbling_covariate %}
-                {# Show message for block garbling #}
-                This survey question is designed to guarantee that
-                at least {{ garbling_percent }}% of recorded responses
-                will be "{{ garbling_answer }}". We do so by having
-                the application automatically switch {{ garbling_percent }}%
-                of responses to "{{ garbling_answer }}".
-                <br>
-                <br>
-                Hence, if we record your response as "{{ garbling_answer }}",
-                no one can really know for sure whether you truly responded
-                "{{ garbling_answer }}" or whether the application switched
-                your response to "{{ garbling_answer }}". This keeps your
-                information very private.
-              {% else %}
-                {# Show message for IID garbling #}
-                This survey question randomly switches your response to
-                "{{ garbling_answer }}" with {{ garbling_percent }}% chance.
-                Hence, if we record your response as "{{ garbling_answer }}",
-                no one can really know for sure whether you truly responded
-                "{{ garbling_answer }}" or whether your response was randomly
-                switched to "{{ garbling_answer }}". This keeps your
-                information very private.
-              {% endif %}
-            </div>
-          </div>
-        </div>
+    <div class="alert alert-light border-2">
+      <div class="accordion-button">
+        <i class="bi bi-info-circle" style="font-size: x-large; color: cornflowerblue;"></i>
+        <span class="px-4">
+          This question uses "garbling"
+          to keep your response private.
+        </span>
+      </div>
+      <hr>
+      <div class="accordion-body">
+        {% if garbling_covariate %}
+          {# Show message for block garbling #}
+          This survey question is designed to guarantee that
+          at least {{ garbling_percent }}% of recorded responses
+          will be "{{ garbling_answer }}". We do so by having
+          the application automatically switch {{ garbling_percent }}%
+          of responses to "{{ garbling_answer }}".
+          <br>
+          <br>
+          Hence, if we record your response as "{{ garbling_answer }}",
+          no one can really know for sure whether you truly responded
+          "{{ garbling_answer }}" or whether the application switched
+          your response to "{{ garbling_answer }}". This keeps your
+          information very private.
+        {% else %}
+          {# Show message for IID garbling #}
+          This survey question randomly switches your response to
+          "{{ garbling_answer }}" with {{ garbling_percent }}% chance.
+          Hence, if we record your response as "{{ garbling_answer }}",
+          no one can really know for sure whether you truly responded
+          "{{ garbling_answer }}" or whether your response was randomly
+          switched to "{{ garbling_answer }}". This keeps your
+          information very private.
+        {% endif %}
       </div>
     </div>
   {% endif %}

--- a/safely_report/templates/survey/layout.html
+++ b/safely_report/templates/survey/layout.html
@@ -10,6 +10,12 @@
     </div>
   {% endif %}
 
+  {% if not is_testing_mode %}
+    <div class="alert alert-info text-center" role="alert">
+      NOTE: Leaving the survey without submitting will result in lost responses
+    </div>
+  {% endif %}
+
   <div class="d-flex justify-content-center">
     {% set message = "Sure to exit? Progress will not be saved." %}
     <a


### PR DESCRIPTION
 # Description

This PR integrates minor feedback from the PIs. Specifically, changes include:

- Update Docker image build to use amd64 instead of arm64
- Display garbling information in full (i.e., no collapsible accordion)
- Add a warning that the survey cannot be paused